### PR TITLE
[Fix] Export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE instead of SINK_LIGHTWEIGHT_VERSION

### DIFF
--- a/sink-connector-lightweight/docker/start-docker-compose.sh
+++ b/sink-connector-lightweight/docker/start-docker-compose.sh
@@ -4,9 +4,9 @@
 if [ -z $1 ]
 then
   echo 'Using the latest tag for Sink connector'
-  export SINK_LIGHTWEIGHT_VERSION='latest'
+  export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE='latest'
 else
-  export SINK_LIGHTWEIGHT_VERSION=$1
+  export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE=$1
 fi
 
 ./stop-docker-compose.sh


### PR DESCRIPTION
# What
`SINK_LIGHTWEIGHT_VERSION` was getting exported instead of `CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE` in [sink-connector-lightweight/docker/start-docker-compose.sh](https://github.com/Altinity/clickhouse-sink-connector/blob/develop/sink-connector-lightweight/docker/start-docker-compose.sh)
 
# Why
If `CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE` is not exported then it was leading to empty string in image id of `clickhouse-sink-connector-lt`